### PR TITLE
Add port GCC_RISC_V_GENERIC and IAR_RISC_V_GENERIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ endif()
 # Heap number or absolute path to custom heap implementation provided by user
 set(FREERTOS_HEAP "4" CACHE STRING "FreeRTOS heap model number. 1 .. 5. Or absolute path to custom heap source file")
 
-string(FIND ${FREERTOS_PORT} "RISC_V" IS_PORT_RISCV)
 # FreeRTOS port option
 if(NOT FREERTOS_PORT)
     message(WARNING " FREERTOS_PORT is not set. Please specify it from top-level CMake file (example):\n"
@@ -107,6 +106,8 @@ if(NOT FREERTOS_PORT)
         " GCC_PPC405_XILINX                - Compiler: GCC           Target: Xilinx PPC405\n"
         " GCC_PPC440_XILINX                - Compiler: GCC           Target: Xilinx PPC440\n"
         " GCC_RISC_V                       - Compiler: GCC           Target: RISC-V\n"
+        " GCC_RISC_V_PULPINO_VEGA_RV32M1RM - Compiler: GCC           Target: RISC-V Pulpino Vega RV32M1RM\n"
+        " GCC_RISC_V_GENERIC               - Compiler: GCC           Target: RISC-V with FREERTOS_RISCV_EXTENSION\n"
         " GCC_RL78                         - Compiler: GCC           Target: Renesas RL78\n"
         " GCC_RX100                        - Compiler: GCC           Target: Renesas RX100\n"
         " GCC_RX200                        - Compiler: GCC           Target: Renesas RX200\n"
@@ -157,6 +158,7 @@ if(NOT FREERTOS_PORT)
         " IAR_MSP430                       - Compiler: IAR           Target: MSP430\n"
         " IAR_MSP430X                      - Compiler: IAR           Target: MSP430X\n"
         " IAR_RISC_V                       - Compiler: IAR           Target: RISC-V\n"
+        " IAR_RISC_V_GENERIC               - Compiler: IAR           Target: RISC-V with FREERTOS_RISCV_EXTENSION\n"
         " IAR_RL78                         - Compiler: IAR           Target: Renesas RL78\n"
         " IAR_RX100                        - Compiler: IAR           Target: Renesas RX100\n"
         " IAR_RX600                        - Compiler: IAR           Target: Renesas RX600\n"
@@ -207,18 +209,6 @@ if(NOT FREERTOS_PORT)
         message(STATUS " Auto-Detected MINGW, setting FREERTOS_PORT=MSVC_MINGW")
         set(FREERTOS_PORT MSVC_MINGW CACHE STRING "FreeRTOS port name")
     endif()
-elseif((IS_PORT_RISCV GREATER -1) AND (NOT FREERTOS_RISCV_EXTENSION))
-    message(FATAL_ERROR " FREERTOS_RISCV_EXTENSION is not set. Please specify it from top-level CMake file (example):\n"
-        "   set(FREERTOS_RISCV_EXTENSION RISCV_MTIME_CLINT_no_extensions CACHE STRING \"\")\n"
-        " or from CMake command line option:\n"
-        "   -DFREERTOS_RISCV_EXTENSION=RISCV_MTIME_CLINT_no_extensions\n"
-        "\n"
-        " Available extension options:\n"
-        " Pulpino_Vega_RV32M1RM            - Compiler: GCC\n"
-        " RISCV_MTIME_CLINT_no_extensions  - Compiler: GCC\n"
-        " RISCV_no_extensions              - Compiler: GCC\n"
-        " RV32I_CLINT_no_extensions        - Compiler: GCC\n"
-        " RV32I_CLINT_no_extensions        - Compiler: IAR\n")
 elseif((FREERTOS_PORT STREQUAL "A_CUSTOM_PORT") AND (NOT TARGET freertos_kernel_port) )
     message(FATAL_ERROR " FREERTOS_PORT is set to A_CUSTOM_PORT. Please specify the custom port target with all necessary files. For example:\n"
     " Assuming a directory of:\n"

--- a/portable/CMakeLists.txt
+++ b/portable/CMakeLists.txt
@@ -1,3 +1,11 @@
+if( FREERTOS_PORT STREQUAL "GCC_RISC_V_GENERIC" )
+    include( GCC/RISC-V/chip_extensions.cmake )
+endif()
+
+if( FREERTOS_PORT STREQUAL "IAR_RISC_V_GENERIC" )
+    include( IAR/RISC-V/chip_extensions.cmake )
+endif()
+
 # FreeRTOS internal cmake file. Do not use it in user top-level project
 
 if (FREERTOS_PORT STREQUAL "A_CUSTOM_PORT")
@@ -284,6 +292,14 @@ add_library(freertos_kernel_port STATIC
         GCC/RISC-V/port.c
         GCC/RISC-V/portASM.S>
 
+    $<$<STREQUAL:${FREERTOS_PORT},GCC_RISC_V_PULPINO_VEGA_RV32M1RM>:
+        GCC/RISC-V/port.c
+        GCC/RISC-V/portASM.S>
+
+    $<$<STREQUAL:${FREERTOS_PORT},GCC_RISC_V_GENERIC>:
+        GCC/RISC-V/port.c
+        GCC/RISC-V/portASM.S>
+
     # Renesas RL78 port for GCC
     $<$<STREQUAL:${FREERTOS_PORT},GCC_RL78>:
         GCC/RL78/port.c
@@ -486,6 +502,10 @@ add_library(freertos_kernel_port STATIC
 
     # RISC-V architecture port for IAR Embedded Workbench for RISC-V
     $<$<STREQUAL:${FREERTOS_PORT},IAR_RISC_V>:
+        IAR/RISC-V/port.c
+        IAR/RISC-V/portASM.s>
+
+    $<$<STREQUAL:${FREERTOS_PORT},IAR_RISC_V_GENERIC>:
         IAR/RISC-V/port.c
         IAR/RISC-V/portASM.s>
 
@@ -828,6 +848,14 @@ target_include_directories(freertos_kernel_port PUBLIC
     # RISC-V architecture ports for GCC
     $<$<STREQUAL:${FREERTOS_PORT},GCC_RISC_V>:
         ${CMAKE_CURRENT_LIST_DIR}/GCC/RISC-V
+        ${CMAKE_CURRENT_LIST_DIR}/GCC/RISC-V/chip_specific_extensions/RISCV_MTIME_CLINT_no_extensions>
+
+    $<$<STREQUAL:${FREERTOS_PORT},GCC_RISC_V_PULPINO_VEGA_RV32M1RM>:
+        ${CMAKE_CURRENT_LIST_DIR}/GCC/RISC-V
+        ${CMAKE_CURRENT_LIST_DIR}/GCC/RISC-V/chip_specific_extensions/Pulpino_Vega_RV32M1RM>
+
+    $<$<STREQUAL:${FREERTOS_PORT},GCC_RISC_V_GENERIC>:
+        ${CMAKE_CURRENT_LIST_DIR}/GCC/RISC-V
         ${CMAKE_CURRENT_LIST_DIR}/GCC/RISC-V/chip_specific_extensions/${FREERTOS_RISCV_EXTENSION}>
 
     # Renesas RL78 port for GCC
@@ -924,6 +952,10 @@ target_include_directories(freertos_kernel_port PUBLIC
 
     # RISC-V architecture port for IAR Embedded Workbench for RISC-V
     $<$<STREQUAL:${FREERTOS_PORT},IAR_RISC_V>:
+        ${CMAKE_CURRENT_LIST_DIR}/IAR/RISC-V
+        ${CMAKE_CURRENT_LIST_DIR}/IAR/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions>
+
+    $<$<STREQUAL:${FREERTOS_PORT},IAR_RISC_V_GENERIC>:
         ${CMAKE_CURRENT_LIST_DIR}/IAR/RISC-V
         ${CMAKE_CURRENT_LIST_DIR}/IAR/RISC-V/chip_specific_extensions/${FREERTOS_RISCV_EXTENSION}>
 

--- a/portable/GCC/RISC-V/chip_extensions.cmake
+++ b/portable/GCC/RISC-V/chip_extensions.cmake
@@ -1,0 +1,19 @@
+if( FREERTOS_PORT STREQUAL "GCC_RISC_V_GENERIC" )
+    set( VALID_CHIP_EXTENSIONS
+            "Pulpino_Vega_RV32M1RM"
+            "RISCV_MTIME_CLINT_no_extensions"
+            "RISCV_no_extensions"
+            "RV32I_CLINT_no_extensions" )
+
+    if( ( NOT FREERTOS_RISCV_EXTENSION ) OR ( NOT ( ${FREERTOS_RISCV_EXTENSION} IN_LIST VALID_CHIP_EXTENSIONS ) ) )
+        message(FATAL_ERROR
+                "FREERTOS_RISCV_EXTENSION \"${FREERTOS_RISCV_EXTENSION}\" is not set or unsupported.\n"
+                "Please specify it from top-level CMake file (example):\n"
+                "   set(FREERTOS_RISCV_EXTENSION RISCV_MTIME_CLINT_no_extensions CACHE STRING \"\")\n"
+                " or from CMake command line option:\n"
+                "   -DFREERTOS_RISCV_EXTENSION=RISCV_MTIME_CLINT_no_extensions\n"
+                "\n"
+                " Available extension options:\n"
+                "   ${VALID_CHIP_EXTENSIONS} \n")
+    endif()
+endif()

--- a/portable/IAR/RISC-V/chip_extensions.cmake
+++ b/portable/IAR/RISC-V/chip_extensions.cmake
@@ -1,0 +1,16 @@
+if( FREERTOS_PORT STREQUAL "IAR_RISC_V_GENERIC" )
+    set( VALID_CHIP_EXTENSIONS
+            "RV32I_CLINT_no_extensions" )
+
+    if( ( NOT FREERTOS_RISCV_EXTENSION ) OR ( NOT ( ${FREERTOS_RISCV_EXTENSION} IN_LIST VALID_CHIP_EXTENSIONS ) ) )
+        message(FATAL_ERROR
+                "FREERTOS_RISCV_EXTENSION \"${FREERTOS_RISCV_EXTENSION}\" is not set or unsupported.\n"
+                "Please specify it from top-level CMake file (example):\n"
+                "   set(FREERTOS_RISCV_EXTENSION RISCV_MTIME_CLINT_no_extensions CACHE STRING \"\")\n"
+                " or from CMake command line option:\n"
+                "   -DFREERTOS_RISCV_EXTENSION=RISCV_MTIME_CLINT_no_extensions\n"
+                "\n"
+                " Available extension options:\n"
+                "   ${VALID_CHIP_EXTENSIONS} \n")
+    endif()
+endif()


### PR DESCRIPTION
Description
-----------
In order not to break existing risc-v project with cmake, two new ports are created:
* GCC_RISC_V_GENERIC
* IAR_RISC_V_GENERIC

`FREERTOS_CHIP_EXTENSION `has to be specify when using these ports.

Test Steps
-----------
Create a RISC-V cmake project to use port GCC_RISC_V_GENERIC.
There will be error message If `FREERTOS_RISCV_EXTENSION `is not set or not supported.
```
cmake -S . -B build
-- The C compiler identification is GNU 10.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at /home/chinglee/kernel/FreeRTOS/FreeRTOS/Source/portable/GCC/RISC-V/chip_extensions.cmake:9 (message):
  FREERTOS_RISCV_EXTENSION "RISCV_MTIMEaefae_CLINT_no_extensions" is not set
  or unsupported.

  Please specify it from top-level CMake file (example):

     set(FREERTOS_RISCV_EXTENSION RISCV_MTIME_CLINT_no_extensions CACHE STRING "")
   or from CMake command line option:
     -DFREERTOS_RISCV_EXTENSION=RISCV_MTIME_CLINT_no_extensions



   Available extension options:
     Pulpino_Vega_RV32M1RM;RISCV_MTIME_CLINT_no_extensions;RISCV_no_extensions;RV32I_CLINT_no_extensions

Call Stack (most recent call first):
  /home/chinglee/kernel/FreeRTOS/FreeRTOS/Source/portable/CMakeLists.txt:2 (include)


-- Configuring incomplete, errors occurred!
See also "/home/chinglee/kernel/FreeRTOS/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/build/CMakeFiles/CMakeOutput.log".

```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
